### PR TITLE
Refactor particle system I/O for safer parsing and const-correct API

### DIFF
--- a/src/ParticleSystem/ParticleData.h
+++ b/src/ParticleSystem/ParticleData.h
@@ -39,7 +39,7 @@ public:
     inline void SetFlagFixed(bool flagFixed) { m_flagFixed = flagFixed; }
     inline bool GetFlagFixed() { return m_flagFixed; }
 
-    inline int GetNumOfSamples() { return int(m_vecSamplePos.size()); }
+    inline int GetNumOfSamples() const { return int(m_vecSamplePos.size()); }
 
     void RenderSoftBody(Vec3f trans = Vec3f(0.0f, 0.0f, 0.0f));
 

--- a/src/ParticleSystem/ParticleSystem.cpp
+++ b/src/ParticleSystem/ParticleSystem.cpp
@@ -1,5 +1,18 @@
 #include "ParticleSystem.h"
 
+namespace
+{
+string GetFileSuffix(const string& fileName)
+{
+    const size_t dotPos = fileName.find_last_of('.');
+    if (dotPos == string::npos || dotPos + 1 >= fileName.size())
+    {
+        return string();
+    }
+    return fileName.substr(dotPos + 1);
+}
+}
+
 CParticleSystem::CParticleSystem()
 {
 }
@@ -66,10 +79,16 @@ bool CParticleSystem::LoadParticleSystemFromCSV(const string& fileName)
         std::cout << "Failed to load particle system from " << fileName << "!\n";
         return false;
     }
+    ClearParticleSystem();
+
     std::string line_str;
-    //std::getline(fin, line_str); // skip the first line
     while (std::getline(fin, line_str))
     {
+        if (line_str.empty())
+        {
+            continue;
+        }
+
         std::stringstream line_ss(line_str);
         std::string cell_str;
 
@@ -96,6 +115,11 @@ bool CParticleSystem::LoadParticleSystemFromCSV(const string& fileName)
             ss4 >> pos_z;
 
             vertices[i] = Vec3f(pos_x, pos_y, pos_z);
+        }
+
+        if (vertices.empty())
+        {
+            continue;
         }
 
         CParticleData particle;
@@ -135,7 +159,7 @@ bool CParticleSystem::SaveParticleSystemAsCSV(const string& fileName)
 
 bool CParticleSystem::LoadParticleSystem(const string& fileName)
 {
-    string suffix = fileName.substr(fileName.rfind(".") + 1, fileName.size());
+    const string suffix = GetFileSuffix(fileName);
     if (suffix == string("csv"))
     {
         return LoadParticleSystemFromCSV(fileName);
@@ -148,7 +172,7 @@ bool CParticleSystem::LoadParticleSystem(const string& fileName)
 
 bool CParticleSystem::SaveParticleSystem(const string& fileName)
 {
-    string suffix = fileName.substr(fileName.rfind(".") + 1, fileName.size());
+    const string suffix = GetFileSuffix(fileName);
     if (suffix == string("csv"))
     {
         return SaveParticleSystemAsCSV(fileName);

--- a/src/ParticleSystem/ParticleSystem.h
+++ b/src/ParticleSystem/ParticleSystem.h
@@ -20,9 +20,9 @@ public:
 
     bool SaveParticleSystem(const string& fileName);
 
-    inline int GetNumOfSoftBodies() { return int(m_vecParticleData.size()); }
+    inline int GetNumOfSoftBodies() const { return int(m_vecParticleData.size()); }
 
-    inline int GetNumOfSamples()
+    inline int GetNumOfSamples() const
     {
         if (m_vecParticleData.empty() == true)
         {
@@ -40,7 +40,7 @@ public:
 
     inline void ResizeParticleSystem(int sz) { m_vecParticleData.resize(sz); }
 
-    inline void AddParticle(CParticleData& particle) { m_vecParticleData.push_back(particle); }
+    inline void AddParticle(const CParticleData& particle) { m_vecParticleData.push_back(particle); }
 
     void SetNeighboringSamples(Flt neighDist);
 


### PR DESCRIPTION
### Motivation
- Increase robustness of particle system file I/O to avoid undefined behavior when parsing malformed CSV input or filenames without extensions. 
- Prevent accidental accumulation of loaded data when re-loading particle CSVs. 
- Improve API correctness and intent by adding const qualification and using const references where appropriate.

### Description
- Added a local `GetFileSuffix` helper (anonymous namespace) in `src/ParticleSystem/ParticleSystem.cpp` to centralize and harden file-extension extraction. 
- Rewrote CSV loader (`LoadParticleSystemFromCSV`) to call `ClearParticleSystem()` before loading, skip empty lines, and skip entries with zero parsed vertices to avoid out-of-bounds access. 
- Switched load/save dispatch to use `GetFileSuffix` instead of raw `substr` slicing. 
- Updated `CParticleSystem` API in `src/ParticleSystem/ParticleSystem.h`: `GetNumOfSoftBodies()` and `GetNumOfSamples()` are now `const`, and `AddParticle` now accepts `const CParticleData&`.

### Testing
- Ran CMake configure and build: `cmake -S . -B build && cmake --build build -j2`; configuration failed due to missing system OpenGL development libraries (`OPENGL_opengl_LIBRARY`, `OPENGL_glx_LIBRARY`, `OPENGL_INCLUDE_DIR`), so a full build/test could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0290fb0f248325a6725948f8ba2da9)